### PR TITLE
releasetools: Store the build.prop file in the OTA zip

### DIFF
--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -704,6 +704,9 @@ endif;
   script.AddToZip(input_zip, output_zip, input_path=OPTIONS.updater_binary)
   WriteMetadata(metadata, output_zip)
 
+  common.ZipWriteStr(output_zip, "system/build.prop",
+                     ""+input_zip.read("SYSTEM/build.prop"))
+
   common.ZipWriteStr(output_zip, "META-INF/org/cyanogenmod/releasekey",
                      ""+input_zip.read("META/releasekey.txt"))
 


### PR DESCRIPTION
This file is often used to read information about the update contained
in the OTA. Place it in the update so it can be used by scripts.

The file is not added to the updater-script, so it will not be placed
onto the actual system.

Change-Id: I88044796cbe8f199ca02df2840fd944cba2c73fa